### PR TITLE
Fix cars falling through track on level2

### DIFF
--- a/Assets/Scenes/Levels/SecondTrack.unity
+++ b/Assets/Scenes/Levels/SecondTrack.unity
@@ -10280,7 +10280,7 @@ Transform:
   m_GameObject: {fileID: 1047565880}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.8, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/RaceSetup.cs
+++ b/Assets/Scripts/RaceSetup.cs
@@ -37,7 +37,7 @@ public class RaceSetup : MonoBehaviour
     void SpawnRacers()
     {
         GameObject car;
-        car = Instantiate(PersistentData.persistentData.getCharacter().characterModelPlayer, characterStartPositions[5], new Quaternion());
+        car = Instantiate(PersistentData.persistentData.getCharacter().characterModelPlayer, transform.position+characterStartPositions[5], new Quaternion());
         car.GetComponent<CarController>().character = PersistentData.persistentData.getCharacter();
         car.GetComponent<CarController>().enabled = false;
         car.tag = "Player";
@@ -51,7 +51,7 @@ public class RaceSetup : MonoBehaviour
                 characterNumber++;
                 if (characterNumber == possibleCharacters.Length) characterNumber = 0;
             }
-            car = Instantiate(possibleCharacters[characterNumber].characterModelAI, characterStartPositions[x], new Quaternion());
+            car = Instantiate(possibleCharacters[characterNumber].characterModelAI, transform.position + characterStartPositions[x], new Quaternion());
             car.GetComponent<AICarDrive>().character = possibleCharacters[characterNumber];
             car.GetComponent<AICarDrive>().SetWaypoints(routes[possibleCharacters[characterNumber].prefferedAITrackRoute].route);
             car.GetComponent<AICarDrive>().enabled = false;


### PR DESCRIPTION
Made the cars spawn higher on level 2 to prevent them from spawning inside the track collider.